### PR TITLE
Update 9 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Configuration.nuspec
+++ b/MakoIoT.Device.Services.Configuration.nuspec
@@ -17,14 +17,14 @@
     <description>MAKO-IoT configuration library.</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.DependencyInjection" version="1.0.15.33629" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.15.14787" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.12.0" />
-      <dependency id="nanoFramework.Logging" version="1.1.47" />
-      <dependency id="nanoFramework.System.Collections" version="1.4.0" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.27" />
-      <dependency id="nanoFramework.System.Text" version="1.2.22" />
-      <dependency id="nanoFramework.Json" version="2.2.72" />
+      <dependency id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.Logging" version="1.1.63" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.18" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
+      <dependency id="nanoFramework.System.Text" version="1.2.37" />
+      <dependency id="nanoFramework.Json" version="2.2.84" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Services.Configuration.Test/MakoIoT.Device.Services.Configuration.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.Configuration.Test/MakoIoT.Device.Services.Configuration.Test.nfproj
@@ -33,22 +33,23 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.15.14787\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.17.36444\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.12.0\lib\mscorlib.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.47.7077, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.47\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.53.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.53\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.59\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.53\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.59\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -61,7 +62,7 @@
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <!-- MANUAL UPDATE HERE -->
-  <Import Project="..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets')" />
+  <Import Project="..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets" Condition="Exists('..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>
       <ProjectConfigurationsDeclaredAsItems />
@@ -71,8 +72,8 @@
     <PropertyGroup>
       <WarningText>Update the Import path in nfproj to the correct nanoFramework.TestFramework NuGet package folder.</WarningText>
     </PropertyGroup>
-    <Warning Condition="!Exists('..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets')" Text="'$(WarningText)'" />
-    <Error Condition="!Exists('..\..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets'))" />
+    <Warning Condition="!Exists('..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets')" Text="'$(WarningText)'" />
+    <Error Condition="!Exists('..\..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets'))" />
   </Target>
-  <Import Project="..\..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets" Condition="Exists('..\..\packages\nanoFramework.TestFramework.2.1.53\build\nanoFramework.TestFramework.targets')" />
+  <Import Project="..\..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets" Condition="Exists('..\..\packages\nanoFramework.TestFramework.2.1.59\build\nanoFramework.TestFramework.targets')" />
 </Project>

--- a/Tests/MakoIoT.Device.Services.Configuration.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.Configuration.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.15.14787" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.12.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Logging" version="1.1.47" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.53" targetFramework="netnanoframework10" developmentDependency="true" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="2.1.59" targetFramework="netnanoframework10" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.Configuration/MakoIoT.Device.Services.Configuration.nfproj
+++ b/src/MakoIoT.Device.Services.Configuration/MakoIoT.Device.Services.Configuration.nfproj
@@ -24,32 +24,36 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.DependencyInjection.1.0.15.33629\lib\MakoIoT.Device.Services.DependencyInjection.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.DependencyInjection.1.0.17.52441\lib\MakoIoT.Device.Services.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.15.14787\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.17.36444\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.12.0\lib\mscorlib.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.72.60323, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Json.2.2.72\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.47.7077, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.47\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.84.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Json.2.2.84\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.4.0\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.22\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.27\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Streams, Version=1.1.38.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Services.Configuration/packages.config
+++ b/src/MakoIoT.Device.Services.Configuration/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.DependencyInjection" version="1.0.15.33629" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.15.14787" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.12.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Json" version="2.2.72" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.47" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.4.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.22" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Json" version="2.2.84" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.5.119" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.DependencyInjection from 1.0.15.33629 to 1.0.17.52441</br>Bumps MakoIoT.Device.Services.Interface from 1.0.15.14787 to 1.0.17.36444</br>Bumps nanoFramework.CoreLibrary from 1.12.0 to 1.14.2</br>Bumps nanoFramework.Json from 2.2.72 to 2.2.84</br>Bumps nanoFramework.Logging from 1.1.47 to 1.1.63</br>Bumps nanoFramework.System.Collections from 1.4.0 to 1.5.18</br>Bumps nanoFramework.System.IO.Streams from 1.1.27 to 1.1.38</br>Bumps nanoFramework.System.Text from 1.2.22 to 1.2.37</br>Bumps nanoFramework.TestFramework from 2.1.53 to 2.1.59</br>
[version update]

### :warning: This is an automated update. :warning:
