### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/Tests/MakoIoT.Device.Services.Configuration.Test/MakoIoT.Device.Services.Configuration.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.Configuration.Test/MakoIoT.Device.Services.Configuration.Test.nfproj
@@ -44,12 +44,12 @@
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.81.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.81\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.UnitTestLauncher, Version=2.1.81.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.81\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/MakoIoT.Device.Services.Configuration.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.Configuration.Test/packages.config
@@ -4,5 +4,5 @@
   <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.0.22" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.81" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.85" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 2.1.81 to 2.1.85</br>
[version update]

### :warning: This is an automated update. :warning:
